### PR TITLE
don't install if manta is already installed

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,7 +19,9 @@
 include_recipe "nodejs::default"
 include_recipe "manta::keys"
 
-npm_package "manta"
+npm_package "manta" do
+  not_if "npm list -g manta"
+end
 
 user = node["manta"]["user"]
 install_path = node["manta"]["install_path"]


### PR DESCRIPTION
most npm providers are too dumb to idempotently install the manta module - this patch makes things faster

@sax @hjhart
